### PR TITLE
docs: add separate Russian README and restore English README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 `swarm` is a Codex/Claude skill for team-based parallel execution.
 It is based on Anthropic Agent Teams documentation: https://code.claude.com/docs/en/agent-teams
 
+Русская версия: [README.ru.md](README.ru.md)
+
 ## What it does
 
 - Triggers when users ask to run work with a team or in parallel.
@@ -13,7 +15,8 @@ It is based on Anthropic Agent Teams documentation: https://code.claude.com/docs
 ## Repository structure
 
 - `SKILL.md` - full skill instructions and workflow.
-- `README.md` - project overview.
+- `README.md` - project overview (English).
+- `README.ru.md` - обзор проекта (Русский).
 - `LICENSE` - MIT license.
 - `install.sh` - one-command shell installer.
 - `scripts/install.js` - Node.js installer (for `npx`).

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,87 @@
+# Swarm Skill
+
+`swarm` — это навык Codex/Claude для командного параллельного выполнения задач.
+Он основан на документации Anthropic Agent Teams: https://code.claude.com/docs/en/agent-teams
+
+English version: [README.md](README.md)
+
+## Что делает
+
+- Срабатывает, когда пользователь просит выполнить работу командой или параллельно.
+- Делит работу на 4 агента с чёткими зонами ответственности.
+- Обеспечивает подход «сначала план», а также изоляцию по файловым областям.
+- Требует явного ревью, отслеживания прогресса и корректного завершения.
+
+## Структура репозитория
+
+- `SKILL.md` — полные инструкции и workflow навыка.
+- `README.md` — обзор проекта (English).
+- `README.ru.md` — обзор проекта (Русский).
+- `LICENSE` — лицензия MIT.
+- `install.sh` — shell-установщик одной командой.
+- `scripts/install.js` — установщик на Node.js (для `npx`).
+- `package.json` — метаданные npm и точка входа CLI.
+
+## Быстрая установка
+
+Установка через shell:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/teafey/swarm.skill/main/install.sh | sh
+```
+
+Установка через NPX (из GitHub):
+
+```sh
+npx --yes -p github:teafey/swarm.skill swarm-skill-install
+```
+
+По умолчанию файлы навыка устанавливаются в `${CODEX_HOME:-$HOME/.codex}/skills/swarm`.
+
+## Локальное использование
+
+Поместите эту папку в директорию со skills и убедитесь, что рантайм агента может загрузить `SKILL.md`.
+
+## Использование
+
+Запустите навык в чате, когда нужно параллельное выполнение командой:
+
+```text
+/swarm <task>
+```
+
+Запуск с указанием модели:
+
+```text
+/swarm haiku <task>
+/swarm sonnet <task>
+/swarm opus <task>
+```
+
+Типовые примеры:
+
+```text
+/swarm 1. Add auth middleware 2. Add tests 3. Update docs 4. Wire CI
+/swarm plan.md
+/swarm parallelize checkout flow refactor
+```
+
+Поведение:
+
+1. Разбирает ваш запрос на задачи.
+2. Делит работу ровно на 4 агентов с изолированной областью работы.
+3. Выполняет согласование плана до начала реализации.
+4. Отслеживает прогресс и возвращает итоговое резюме.
+
+## Разработка
+
+1. Измените `SKILL.md`.
+2. Проверьте поведение на реальных промптах, которые включают swarm-режим.
+3. Закоммитьте изменения с понятным scope.
+
+## Публикация
+
+1. `git remote add origin git@github.com:teafey/swarm.skill.git`
+2. `git add .`
+3. `git commit -m "chore: bootstrap swarm skill repo"`
+4. `git push -u origin main`


### PR DESCRIPTION
### Motivation

- The README had been replaced entirely with a Russian translation, but the intent was to provide a separate Russian README while keeping the primary English README intact. 
- Provide bilingual documentation and easy navigation between English and Russian overviews.

### Description

- Restored the original English `README.md` content and added a cross-link to the Russian file. 
- Added a new `README.ru.md` containing a full Russian translation of the README content. 
- Updated repository structure section in the English README to reference `README.ru.md` as the Russian overview. 
- This is a documentation-only change and does not modify code or runtime behavior.

### Testing

- Inspected `README.md` to confirm it contains the English content and the link to `README.ru.md` (succeeded). 
- Opened and reviewed `README.ru.md` to confirm a complete Russian translation of the README (succeeded). 
- Compared diffs to ensure only documentation files were added/changed and no source code was altered (succeeded). 
- Verified the working tree shows only the intended README changes and the new file (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956f88a70c8320b99ee42c06611a79)